### PR TITLE
AR-795 Fix costmap to world coordinates conversion

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
@@ -46,9 +46,9 @@ inline geometry_msgs::msg::Pose getWorldCoords(
 {
   geometry_msgs::msg::Pose msg;
   msg.position.x =
-    static_cast<float>(costmap->getOriginX()) + (mx + 0.5) * costmap->getResolution();
+    static_cast<float>(costmap->getOriginX()) + (mx - 0.5) * costmap->getResolution();
   msg.position.y =
-    static_cast<float>(costmap->getOriginY()) + (my + 0.5) * costmap->getResolution();
+    static_cast<float>(costmap->getOriginY()) + (my - 0.5) * costmap->getResolution();
   return msg;
 }
 

--- a/nav2_smac_planner/test/test_utils.cpp
+++ b/nav2_smac_planner/test/test_utils.cpp
@@ -147,3 +147,17 @@ TEST(create_marker, test_createMarker)
   EXPECT_EQ(marker2.id, 8u);
   EXPECT_EQ(marker2.points.size(), 0u);
 }
+
+TEST(convert_map_to_world_to_map, test_convert_map_to_world_to_map)
+{
+  auto costmap = nav2_costmap_2d::Costmap2D(10.0, 10.0, 0.05, 0.0, 0.0, 0);
+
+  float mx = 200.0;
+  float my = 100.0;
+  geometry_msgs::msg::Pose pose = getWorldCoords(mx, my, &costmap);
+
+  float mx1, my1;
+  costmap.worldToMapContinuous(pose.position.x, pose.position.y, mx1, my1);
+  EXPECT_NEAR(mx, mx1, 1e-3);
+  EXPECT_NEAR(my, my1, 1e-3);
+}


### PR DESCRIPTION

## Description of contribution in a few bullet points

It is [assumed](https://github.com/ros-navigation/navigation2/blob/30f028d1bf5a4cb3ba429061823135ba6b394ca9/nav2_planner/src/planner_server.cpp#L407-L410) that the end pose for path1 is the start pose for path2 

But when we convert the goal from map coordinates to world coordinates and then back to map coordinates it ends up in a different map cell: 
![Screenshot from 2024-07-01 13-36-56](https://github.com/angsa-robotics/navigation2/assets/72872431/b77cc714-d9c8-449a-bcc3-141070de620d)

When converting from world to map coordinates we [add](https://github.com/ros-navigation/navigation2/blob/30f028d1bf5a4cb3ba429061823135ba6b394ca9/nav2_costmap_2d/src/costmap_2d.cpp#L299-L312) 0.5. So when we are converting back we should subtract 0.5, otherwise we end up in the next cell




Path before: 
![Screenshot from 2024-07-01 13-33-38](https://github.com/angsa-robotics/navigation2/assets/72872431/44732012-d4c2-4a69-9187-1ecfd3d5f0bf)
Path after: 
![Screenshot from 2024-07-01 13-35-33](https://github.com/angsa-robotics/navigation2/assets/72872431/34d9e8d8-6ce0-4914-bfb0-5d7f8f0e7573)

Conversion result after these changes:
![Screenshot from 2024-07-01 13-36-14](https://github.com/angsa-robotics/navigation2/assets/72872431/518e87f9-a845-4bcb-88de-e48ee76bcdf8)


