### PR TITLE
AR-784 Save Behavior Trees in cache and reload only if XML file content changed

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -88,7 +88,7 @@ public:
    * @brief Function to explicitly reset all BT nodes to initial state
    * @param tree Tree to halt
    */
-  void haltAllActions(BT::Tree & tree);
+  void haltAllActions(BT::Tree* tree);
 
 protected:
   // The factory that will be used to dynamically construct the behavior tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -169,7 +169,7 @@ public:
    * @brief Getter function for the current BT tree
    * @return BT::Tree Current behavior tree
    */
-  const BT::Tree & getTree() const
+  const BT::Tree* getTree() const
   {
     return tree_;
   }
@@ -181,7 +181,7 @@ public:
    */
   void haltTree()
   {
-    tree_.haltTree();
+    tree_->haltTree();
   }
 
 protected:
@@ -209,7 +209,10 @@ protected:
   std::shared_ptr<ActionServer> action_server_;
 
   // Behavior Tree to be executed when goal is received
-  BT::Tree tree_;
+  BT::Tree* tree_;
+
+  // First element is a pair of BT filename and BT xml hash, second is the tree itself
+  std::map<std::string, std::pair<size_t, BT::Tree>> cached_trees_;
 
   // The blackboard shared by all of the nodes in the tree
   BT::Blackboard::Ptr blackboard_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -211,7 +211,8 @@ protected:
   // Behavior Tree to be executed when goal is received
   BT::Tree* tree_;
 
-  // First element is a pair of BT filename and BT xml hash, second is the tree itself
+  // Stores loaded Behavior Trees, their names and hashes
+  // std::map<filename, std::pair<hash, BT>>
   std::map<std::string, std::pair<size_t, BT::Tree>> cached_trees_;
 
   // The blackboard shared by all of the nodes in the tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -220,7 +220,6 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   // Empty filename is default for backward compatibility
   auto filename = bt_xml_filename.empty() ? default_bt_xml_filename_ : bt_xml_filename;
 
-
   // Thich check is commented out in favor of the BT caching logic
   // Use previous BT if it is the existing one 
   // if (current_bt_xml_filename_ == filename) {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -249,7 +249,7 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
       }
       else {
         cached_trees_.erase(it);
-        RCLCPP_INFO(logger_, "Overriding previously cached BT: %s as its hash changed");
+        RCLCPP_INFO(logger_, "Overriding previously cached BT: %s as its hash changed", filename.c_str());
       }
       break;
     }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -220,24 +220,54 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   // Empty filename is default for backward compatibility
   auto filename = bt_xml_filename.empty() ? default_bt_xml_filename_ : bt_xml_filename;
 
-  // Use previous BT if it is the existing one
-  if (current_bt_xml_filename_ == filename) {
-    RCLCPP_DEBUG(logger_, "BT will not be reloaded as the given xml is already loaded");
-    return true;
-  }
+
+  // Thich check is commented out in favor of the BT caching logic
+  // Use previous BT if it is the existing one 
+  // if (current_bt_xml_filename_ == filename) {
+  //   RCLCPP_DEBUG(logger_, "BT will not be reloaded as the given xml is already loaded");
+  //   return true;
+  // }
 
   // Read the input BT XML from the specified file into a string
+
+  tree_ = nullptr;
   std::ifstream xml_file(filename);
 
-  if (!xml_file.good()) {
-    RCLCPP_ERROR(logger_, "Couldn't open input XML file: %s", filename.c_str());
-    return false;
+  // Create hash from BT xml file
+  std::string xml_string = std::string(std::istreambuf_iterator<char>(xml_file), std::istreambuf_iterator<char>());
+  std::hash<std::string> hasher;
+  size_t xml_hash = hasher(xml_string);
+
+
+  // Check if we already have this BT in cache and use it
+  for(std::map<std::string, std::pair<size_t, BT::Tree>>::iterator it = cached_trees_.begin(); it != cached_trees_.end(); ++it) {
+    if (it->first == filename)
+    {
+      if (it->second.first == xml_hash)
+      {
+        RCLCPP_DEBUG(logger_, "BT exists in cache, will not reload");
+        tree_= &it->second.second;
+      }
+      else {
+        cached_trees_.erase(it);
+        RCLCPP_INFO(logger_, "Overriding previously cached BT: %s as its hash changed");
+      }
+      break;
+    }
   }
 
-  // Create the Behavior Tree from the XML input
   try {
-    tree_ = bt_->createTreeFromFile(filename, blackboard_);
-    for (auto & blackboard : tree_.blackboard_stack) {
+    if (tree_ == nullptr){
+      // BT with this same xml content was not found in cache. Loading
+      if (!xml_file.good()) {
+        RCLCPP_ERROR(logger_, "Couldn't open input XML file: %s", filename.c_str());
+        return false;
+      }
+      cached_trees_[filename].first = xml_hash;
+      cached_trees_[filename].second = bt_->createTreeFromFile(filename, blackboard_); 
+      tree_ = &cached_trees_[filename].second;
+    }
+    for (auto & blackboard : tree_->blackboard_stack) {
       blackboard->set("node", client_node_);
       blackboard->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);
       blackboard->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);
@@ -286,7 +316,7 @@ void BtActionServer<ActionT>::executeCallback()
     };
 
   // Execute the BT that was previously created in the configure step
-  nav2_behavior_tree::BtStatus rc = bt_->run(&tree_, on_loop, is_canceling, bt_loop_duration_);
+  nav2_behavior_tree::BtStatus rc = bt_->run(tree_, on_loop, is_canceling, bt_loop_duration_);
 
   // Make sure that the Bt is not in a running state from a previous execution
   // note: if all the ControlNodes are implemented correctly, this is not needed.

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -220,7 +220,7 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   // Empty filename is default for backward compatibility
   auto filename = bt_xml_filename.empty() ? default_bt_xml_filename_ : bt_xml_filename;
 
-  // Thich check is commented out in favor of the BT caching logic
+  // This check is commented out in favor of the BT caching logic
   // Use previous BT if it is the existing one 
   // if (current_bt_xml_filename_ == filename) {
   //   RCLCPP_DEBUG(logger_, "BT will not be reloaded as the given xml is already loaded");

--- a/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
@@ -39,8 +39,8 @@ public:
    * @param ros_node Weak pointer to parent rclcpp::Node
    * @param tree BT to monitor
    */
-  RosTopicLogger(const rclcpp::Node::WeakPtr & ros_node, const BT::Tree & tree)
-  : StatusChangeLogger(tree.rootNode())
+  RosTopicLogger(const rclcpp::Node::WeakPtr & ros_node, const BT::Tree* tree)
+  : StatusChangeLogger(tree->rootNode())
   {
     auto node = ros_node.lock();
     clock_ = node->get_clock();

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -91,10 +91,10 @@ BehaviorTreeEngine::createTreeFromFile(
 
 // In order to re-run a Behavior Tree, we must be able to reset all nodes to the initial state
 void
-BehaviorTreeEngine::haltAllActions(BT::Tree & tree)
+BehaviorTreeEngine::haltAllActions(BT::Tree* tree)
 {
   // this halt signal should propagate through the entire tree.
-  tree.haltTree();
+  tree->haltTree();
 }
 
 }  // namespace nav2_behavior_tree

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -94,7 +94,7 @@ NavigateThroughPosesNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 }
 
 void NavigateThroughPosesNavigator::publishTree(std::string &bt_xml_filename) {
-  const BT::TreeNode* root_node = bt_action_server_->getTree().rootNode();
+  const BT::TreeNode* root_node = bt_action_server_->getTree()->rootNode();
 
   auto behavior_tree_msg = std::make_shared<nav2_msgs::msg::BehaviorTree>();
   behavior_tree_msg->name = bt_xml_filename;

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -109,7 +109,7 @@ NavigateToPoseNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 
 void NavigateToPoseNavigator::publishTree(std::string& bt_xml_filename)
 {
-    const BT::TreeNode* root_node = bt_action_server_->getTree().rootNode();
+  const BT::TreeNode* root_node = bt_action_server_->getTree()->rootNode();
 
   auto behavior_tree_msg = std::make_shared<nav2_msgs::msg::BehaviorTree>();
   behavior_tree_msg->name = bt_xml_filename;


### PR DESCRIPTION
## Description of contribution in a few bullet points

Ticket: https://angsa-robotics-team-i7lircnb8klx.atlassian.net/browse/AR-784

* Cache loaded behavior trees
* When loading the BT check for changes in XML file, if we already have in cache a loaded BT with this XML then use it. otherwise load it
* Remove the BT from cache if hash has changed -> To avoid cache growing in size

This will also reduce the time it takes when switching between BTs
