### PR TITLE
AR-2212 Move intermediate goal sampling to route planner

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.hpp
@@ -66,6 +66,9 @@ public:
         BT::InputPort<int>(
           "nb_goals_to_consider", 5,
           "Number of goals to consider for collision checking"),
+        BT::InputPort<bool>(
+          "update_status", true,
+          "Whether to update the status of the goals"),
         BT::OutputPort<Goals>("output_goals", "Goals with in-collision goals removed"),
       });
   }
@@ -73,6 +76,7 @@ public:
 private:
   bool use_footprint_;
   bool consider_unknown_as_obstacle_;
+  bool update_status_;
   double cost_threshold_;
   Goals input_goals_;
   int nb_goals_to_consider_;

--- a/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
@@ -39,6 +39,7 @@ void RemoveInCollisionGoals::on_tick()
   getInput("input_goals", input_goals_);
   getInput("consider_unknown_as_obstacle", consider_unknown_as_obstacle_);
   getInput("nb_goals_to_consider", nb_goals_to_consider_);
+  getInput("update_status", update_status_);
 
   if (input_goals_.empty()) {
     setOutput("output_goals", input_goals_);
@@ -63,7 +64,9 @@ BT::NodeStatus RemoveInCollisionGoals::on_completion(
   [[maybe_unused]] auto res = config().blackboard->get("goals_feedback", goals_feedback);
   for (int i = static_cast<int>(response->costs.size()) - 1; i >= 0; --i) {
     if ((response->costs[i] != 255 || consider_unknown_as_obstacle_) && response->costs[i] >= cost_threshold_) {
-      goals_feedback[input_goals_[i].index].status = nav2_msgs::msg::Waypoint::SKIPPED;
+      if (update_status_) {
+        goals_feedback[input_goals_[i].index].status = nav2_msgs::msg::Waypoint::SKIPPED;
+      }
       // if it's not valid then we erase it from input_goals_ and set the status to SKIPPED
       input_goals_.erase(input_goals_.begin() + i);
     }

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -432,11 +432,6 @@ void PlannerServer::computePlanThroughPoses()
         curr_path = getPlan(
           curr_start, curr_goal, goal->planner_id,
           cancel_checker);
-      } catch (nav2_core::GoalOutsideMapBounds & ex) {
-        RCLCPP_WARN(
-          get_logger(), "Goal %d coordinates of (%.2f, %.2f) was outside bounds",
-          i, curr_goal.pose.position.x, curr_goal.pose.position.y);
-        continue;
       } catch (nav2_core::StartOccupied & ex) {
         RCLCPP_WARN(
           get_logger(), "Error START_OCCUPIED but probably 2 goals are just too close to each other.");

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -432,6 +432,15 @@ void PlannerServer::computePlanThroughPoses()
         curr_path = getPlan(
           curr_start, curr_goal, goal->planner_id,
           cancel_checker);
+      } catch (nav2_core::GoalOutsideMapBounds & ex) {
+        if (i == 0) {
+          throw ex;
+        } else {
+          RCLCPP_WARN(
+            get_logger(), "Goal %d coordinates of (%.2f, %.2f) was outside bounds but there are still goals inside. Ignoring",
+            i, curr_goal.pose.position.x, curr_goal.pose.position.y);
+          continue;
+        }
       } catch (nav2_core::StartOccupied & ex) {
         RCLCPP_WARN(
           get_logger(), "Error START_OCCUPIED but probably 2 goals are just too close to each other.");

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -437,9 +437,9 @@ void PlannerServer::computePlanThroughPoses()
           throw ex;
         } else {
           RCLCPP_WARN(
-            get_logger(), "Goal %d coordinates of (%.2f, %.2f) was outside bounds but there are still goals inside. Ignoring",
+            get_logger(), "Goal %d coordinates of (%.2f, %.2f) was outside bounds but there are still goals inside. Ignoring the rest",
             i, curr_goal.pose.position.x, curr_goal.pose.position.y);
-          continue;
+          break;
         }
       } catch (nav2_core::StartOccupied & ex) {
         RCLCPP_WARN(


### PR DESCRIPTION
Required for: https://github.com/angsa-robotics/angsa-robot/pull/1716

## Changes

* Make ComputePathThroughPoses throw an exception if first goal is outside costmap
* Add option to not update waypoint status to RemoveInCollisionGoals